### PR TITLE
Add udev rule

### DIFF
--- a/udev_rules/58-rhoeby-scanner2d.rules
+++ b/udev_rules/58-rhoeby-scanner2d.rules
@@ -1,0 +1,2 @@
+# Rhoeby Dynamics R2D LiDAR
+KERNEL=="ttyACM?", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="5740", MODE="0666", SYMLINK+="rhoeby_R2D"

--- a/udev_rules/README.md
+++ b/udev_rules/README.md
@@ -1,0 +1,1 @@
+Copy the file `58-rhoeby-scanner2d.rules` to `/etc/udev/rules.d` to automatically set permissions so that all users can read and write to the device.


### PR DESCRIPTION
I've created a udev rule so that the permissions are set for the R2D LiDAR so that all users can access the device. Additionally it creates a symlink so that multiple ttyACM devices can be used at the same time.
